### PR TITLE
Remove redundant echo statement for mod

### DIFF
--- a/what-are-functions/add_numbers
+++ b/what-are-functions/add_numbers
@@ -15,4 +15,3 @@ check_even () {
 number=2344
 
 check_even $number
-echo $mod


### PR DESCRIPTION
In this Bash script, **mod** is declared using local inside the **check_even** function, which means it is accessible only within that function. Therefore, mod prints correctly inside the function but does not exist outside it. As a result, the final echo **$mod** prints nothing. Bash does not throw an error for undefined variables; it simply expands them to an empty string.